### PR TITLE
Fix import bug in Task module

### DIFF
--- a/arcagi/task.py
+++ b/arcagi/task.py
@@ -2,7 +2,7 @@ import numpy as np
 from arcagi.plotting import plot_task
 from arcagi.grid import Grid
 from arcagi.shapes import Shapes
-from utils import io, tt
+from arcagi.utils import io, tt
 from arcagi.llm import llm, prompt_input_output
 
 class Task():


### PR DESCRIPTION
## Summary
- fix module path for `utils` in `arcagi.task`

## Testing
- `python` import of `Task` with dummy `ollama` and `llm` modules

------
https://chatgpt.com/codex/tasks/task_e_686fab638cf4832b9473fa0f45e0f7d8