### PR TITLE
Fix README method names

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ task
 ![alt text](img/task.png)
 ___
 ```python
-task.tasks_is_same_size_all_input_output()
+task.is_same_size_all_input_output()
 ```
 \> output
 `False`
 ___
 ```python
-task.tasks_is_same_size_each_input_output()
+task.is_same_size_each_input_output()
 ```
 \> output
 `True`


### PR DESCRIPTION
## Summary
- replace old `tasks_is_same_size_*` methods with new names in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686fb36dc73c832ba3d0664af3697f2c